### PR TITLE
Fix cargo install instructions for latest version to use `--path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Installing the latest version:
 ```shell
 git clone git@github.com:finnkauski/huemanity.git
 cd huemanity
-cargo install huemanity
+cargo install --path .
 ```
 
 Installing from [crates.io](https://crates.io/crates/huemanity) (might be outdated):


### PR DESCRIPTION
`cargo install` does not work within a git repository, and `cargo
install huemanity` installs from crates.io and doesn't look at the
current directory. Modify instructions to use `cargo install --path .`
instead.